### PR TITLE
Fix heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Threading Library for Java
+# Threading Library for Java
 
 [![Join the chat at https://gitter.im/tunnelvisionlabs/java-threading](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tunnelvisionlabs/java-threading?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
You can't see it, but there's a unicode character preceding the `#` in the first line that was breaking formatting in markdown rendered views.